### PR TITLE
[FEATURE] Implement Profile Module - Get, Follow, and Unfollow APIs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2596,14 +2596,14 @@
       }
     },
     "node_modules/@nestjs/platform-express": {
-      "version": "11.1.3",
-      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.3.tgz",
-      "integrity": "sha512-hEDNMlaPiBO72fxxX/CuRQL3MEhKRc/sIYGVoXjrnw6hTxZdezvvM6A95UaLsYknfmcZZa/CdG1SMBZOu9agHQ==",
+      "version": "11.1.5",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.5.tgz",
+      "integrity": "sha512-OsoiUBY9Shs5IG3uvDIt9/IDfY5OlvWBESuB/K4Eun8xILw1EK5d5qMfC3d2sIJ+kA3l+kBR1d/RuzH7VprLIg==",
       "license": "MIT",
       "dependencies": {
         "cors": "2.8.5",
         "express": "5.1.0",
-        "multer": "2.0.1",
+        "multer": "2.0.2",
         "path-to-regexp": "8.2.0",
         "tslib": "2.8.1"
       },
@@ -9168,9 +9168,9 @@
       "license": "MIT"
     },
     "node_modules/multer": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-2.0.1.tgz",
-      "integrity": "sha512-Ug8bXeTIUlxurg8xLTEskKShvcKDZALo1THEX5E41pYCD2sCVub5/kIRIGqWNoqV6szyLyQKV6mD4QUrWE5GCQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.0.2.tgz",
+      "integrity": "sha512-u7f2xaZ/UG8oLXHvtF/oWTRvT44p9ecwBBqTwgJVq0+4BW1g8OW01TyMEGWBHbyMOYVHXslaut7qEQ1meATXgw==",
       "license": "MIT",
       "dependencies": {
         "append-field": "^1.0.0",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -55,7 +55,7 @@ model User {
 
   articles    Article[] @relation("UserArticles")
 
-  following   User[]    @relation("FollowRelation")
+  followings  User[]    @relation("FollowRelation")
   followers   User[]    @relation("FollowRelation")
 
   @@map("users")

--- a/prisma/seeds/follow.seed.ts
+++ b/prisma/seeds/follow.seed.ts
@@ -14,7 +14,7 @@ export async function seedFollows(): Promise<void> {
     await prisma.user.update({
       where: { id: followerId },
       data: {
-        following: {
+        followings: {
           connect: { id: followingId },
         },
       },

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -10,9 +10,17 @@ import { ConfigModule } from '@config/config.module';
 import { AuthModule } from '@modules/auth/auth.module';
 import { UserModule } from '@modules/user/user.module';
 import { ArticleModule } from '@modules/article/article.module';
+import { ProfileModule } from '@modules/profile/profile.module';
 
 @Module({
-  imports: [CommonModule, ConfigModule, AuthModule, UserModule, ArticleModule],
+  imports: [
+    CommonModule,
+    ConfigModule,
+    AuthModule,
+    UserModule,
+    ArticleModule,
+    ProfileModule,
+  ],
   controllers: [],
   providers: [],
 })

--- a/src/common/constant/error.constant.ts
+++ b/src/common/constant/error.constant.ts
@@ -129,3 +129,31 @@ export const ERROR_ARTICLE_CONFLICT = {
   message: 'Article with this slug already exists',
   errorCode: 'ERROR_ARTICLE_CONFLICT',
 };
+
+export const ERROR_CANNOT_FOLLOW_SELF = {
+  statusCode: 409,
+  error: 'Conflict',
+  message: 'You cannot follow yourself.',
+  errorCode: 'ERROR_CANNOT_FOLLOW_SELF',
+};
+
+export const ERROR_ALREADY_FOLLOWING = {
+  statusCode: 409,
+  error: 'Conflict',
+  message: 'You are already following this user.',
+  errorCode: 'ERROR_ALREADY_FOLLOWING',
+};
+
+export const ERROR_CANNOT_UNFOLLOW_SELF = {
+  statusCode: 409,
+  error: 'Conflict',
+  message: 'You cannot unfollow yourself.',
+  errorCode: 'ERROR_CANNOT_UNFOLLOW_SELF',
+};
+
+export const ERROR_NOT_FOLLOWING_USER = {
+  statusCode: 409,
+  error: 'Conflict',
+  message: 'You are not following this user.',
+  errorCode: 'ERROR_NOT_FOLLOWING_USER',
+};

--- a/src/common/type/profile-response.interface.ts
+++ b/src/common/type/profile-response.interface.ts
@@ -1,0 +1,23 @@
+export interface Profile {
+  id: number;
+
+  username: string;
+
+  bio: string | null;
+
+  image: string | null;
+}
+
+export interface ProfileResponseData {
+  username: string;
+
+  bio: string | null;
+
+  image: string | null;
+
+  following?: boolean;
+}
+
+export interface ProfileResponse {
+  profile: ProfileResponseData;
+}

--- a/src/modules/profile/profile.controller.ts
+++ b/src/modules/profile/profile.controller.ts
@@ -1,0 +1,68 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Delete,
+  Param,
+  Req,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { ProfileService } from './profile.service';
+import { Request } from 'express';
+import { Auth } from '@common/decorator/auth.decorator';
+import { AuthType } from '@common/type/auth-type.enum';
+import { ResponsePayload } from '@common/type/response.interface';
+
+@Controller('api')
+export class ProfileController {
+  constructor(private readonly profileService: ProfileService) {}
+
+  @Get('profiles/:username')
+  @Auth(AuthType.OPTIONAL)
+  @HttpCode(HttpStatus.OK)
+  async getProfile(
+    @Req() req: Request,
+    @Param('username') username: string,
+  ): Promise<ResponsePayload> {
+    const currentUserId = req.user?.userId;
+    const profile = await this.profileService.getProfile(
+      currentUserId,
+      username,
+    );
+    return {
+      message: 'Profile retrieved successfully',
+      data: profile,
+    };
+  }
+
+  @Auth(AuthType.ACCESS_TOKEN)
+  @Post('profiles/:username/follow')
+  @HttpCode(HttpStatus.OK)
+  async followUser(
+    @Req() req: Request,
+    @Param('username') username: string,
+  ): Promise<ResponsePayload> {
+    const userId = req.user?.userId as number;
+    const profile = await this.profileService.followUser(userId, username);
+    return {
+      message: 'Followed user successfully',
+      data: profile,
+    };
+  }
+
+  @Auth(AuthType.ACCESS_TOKEN)
+  @Delete('profiles/:username/unfollow')
+  @HttpCode(HttpStatus.OK)
+  async unfollowUser(
+    @Req() req: Request,
+    @Param('username') username: string,
+  ): Promise<ResponsePayload> {
+    const userId = req.user?.userId as number;
+    const profile = await this.profileService.unfollowUser(userId, username);
+    return {
+      message: 'Unfollowed user successfully',
+      data: profile,
+    };
+  }
+}

--- a/src/modules/profile/profile.module.ts
+++ b/src/modules/profile/profile.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ProfileService } from './profile.service';
+import { ProfileController } from './profile.controller';
+
+@Module({
+  imports: [],
+  controllers: [ProfileController],
+  providers: [ProfileService],
+})
+export class ProfileModule {}

--- a/src/modules/profile/profile.service.ts
+++ b/src/modules/profile/profile.service.ts
@@ -1,0 +1,130 @@
+import PrismaService from '@common/service/prisma.service';
+import {
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import {
+  ERROR_ALREADY_FOLLOWING,
+  ERROR_CANNOT_FOLLOW_SELF,
+  ERROR_CANNOT_UNFOLLOW_SELF,
+  ERROR_NOT_FOLLOWING_USER,
+  ERROR_USER_NOT_FOUND,
+} from '@common/constant/error.constant';
+import {
+  ProfileResponseData,
+  ProfileResponse,
+  Profile,
+} from '@common/type/profile-response.interface';
+
+@Injectable()
+export class ProfileService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async getProfile(
+    currentUserId: number | undefined,
+    username: string,
+  ): Promise<ProfileResponse> {
+    const user = await this.prisma.user.findUnique({
+      where: { username },
+      select: { id: true, username: true, bio: true, image: true },
+    });
+
+    if (!user) {
+      throw new NotFoundException(ERROR_USER_NOT_FOUND);
+    }
+
+    const { id, ...profile } = user;
+
+    let following: boolean | undefined;
+    if (currentUserId && currentUserId !== id) {
+      const isFollowing = await this.prisma.user.count({
+        where: {
+          id: currentUserId,
+          followings: { some: { id } },
+        },
+      });
+      following = isFollowing > 0;
+    }
+    return this.buildProfileResponse(
+      following !== undefined ? { ...profile, following } : profile,
+    );
+  }
+
+  async unfollowUser(
+    userId: number,
+    username: string,
+  ): Promise<ProfileResponse> {
+    const userToUnfollow = await this.prisma.user.findUnique({
+      where: { username },
+      select: { id: true, username: true, bio: true, image: true },
+    });
+    if (!userToUnfollow) {
+      throw new NotFoundException(ERROR_USER_NOT_FOUND);
+    }
+
+    const { id, ...profile } = userToUnfollow;
+    if (id === userId) {
+      throw new ConflictException(ERROR_CANNOT_UNFOLLOW_SELF);
+    }
+
+    const isFollowing = await this.prisma.user.count({
+      where: {
+        id: userId,
+        followings: { some: { id: userToUnfollow.id } },
+      },
+    });
+    if (isFollowing === 0) {
+      throw new ConflictException(ERROR_NOT_FOLLOWING_USER);
+    }
+
+    await this.prisma.user.update({
+      data: { followings: { disconnect: { id: userToUnfollow.id } } },
+      where: { id: userId },
+    });
+
+    return this.buildProfileResponse({
+      ...profile,
+      following: false,
+    });
+  }
+
+  async followUser(userId: number, username: string): Promise<ProfileResponse> {
+    const userToFollow: Profile | null = await this.prisma.user.findUnique({
+      where: { username: username },
+      select: { id: true, username: true, bio: true, image: true },
+    });
+    if (!userToFollow) {
+      throw new NotFoundException(ERROR_USER_NOT_FOUND);
+    }
+
+    const { id, ...profile } = userToFollow;
+    if (id === userId) {
+      throw new ConflictException(ERROR_CANNOT_FOLLOW_SELF);
+    }
+
+    const isAlreadyFollowing = await this.prisma.user.count({
+      where: {
+        id: userId,
+        followings: { some: { id: userToFollow.id } },
+      },
+    });
+    if (isAlreadyFollowing > 0) {
+      throw new ConflictException(ERROR_ALREADY_FOLLOWING);
+    }
+
+    await this.prisma.user.update({
+      data: { followings: { connect: { id: userToFollow.id } } },
+      where: { id: userId },
+    });
+
+    return this.buildProfileResponse({
+      ...profile,
+      following: true,
+    });
+  }
+
+  private buildProfileResponse(profile: ProfileResponseData): ProfileResponse {
+    return { profile };
+  }
+}


### PR DESCRIPTION
This pull request adds complete profile interaction functionalities, including:
1. Get User Profile (GET `/api/profiles/:username`):
- Allows retrieving a user’s profile by their username
- Supports optional authentication
- If a user is authenticated (i.e., `userId` is present), the response includes a following flag to indicate whether the current user follows the requested profile
- If the request is unauthenticated, the following status is omitted
2. Follow User (POST `/api/profiles/:username/follow`):
- Requires authentication via access token
- Authenticated user can follow another user
- Returns updated profile with following: `true`
3. Unfollow User (DELETE `/api/profiles/:username/unfollow`):
- Requires authentication via access token
- Allows authenticated user to unfollow a previously followed user
- Returns updated profile with following: `false`