### PR TITLE
[FEATURE] Implement Article Favoriting and Unfavoriting Functionality

### DIFF
--- a/src/common/constant/error.constant.ts
+++ b/src/common/constant/error.constant.ts
@@ -88,6 +88,20 @@ export const ERROR_EMAIL_ALREADY_EXISTS = {
   errorCode: 'ERROR_EMAIL_ALREADY_EXISTS',
 };
 
+export const ERROR_ALREADY_FAVORITED = {
+  statusCode: 409,
+  error: 'Conflict',
+  message: 'You have already favorited this article',
+  errorCode: 'ERROR_ALREADY_FAVORITED',
+};
+
+export const ERROR_NOT_FAVORITED_YET = {
+  statusCode: 409,
+  error: 'Conflict',
+  message: 'You have not favorited this article yet',
+  errorCode: 'ERROR_NOT_FAVORITED_YET',
+};
+
 export const ERROR_USERNAME_ALREADY_EXISTS = {
   statusCode: 409,
   error: 'Conflict',

--- a/src/modules/article/article.controller.ts
+++ b/src/modules/article/article.controller.ts
@@ -66,13 +66,18 @@ export class ArticleController {
   async delete(
     @Req() req: Request,
     @Param('slug') slug: string,
-  ): Promise<void> {
+  ): Promise<ResponsePayload> {
     if (!slug || slug.trim() === '') {
       throw new BadRequestException(ERROR_INVALID_SLUG);
     }
 
     const userId = req.user?.userId;
     await this.articleService.deleteArticle(userId as number, slug);
+
+    return {
+      message: 'Delete article successfully',
+      data: {},
+    };
   }
 
   @Post('articles/:slug')

--- a/src/modules/article/article.controller.ts
+++ b/src/modules/article/article.controller.ts
@@ -116,4 +116,42 @@ export class ArticleController {
       data: articles,
     };
   }
+
+  @Post('articles/:slug/favorite')
+  @HttpCode(HttpStatus.OK)
+  @Auth(AuthType.ACCESS_TOKEN)
+  async favorite(
+    @Req() req: Request,
+    @Param('slug') slug: string,
+  ): Promise<ResponsePayload> {
+    if (!slug || slug.trim() === '') {
+      throw new BadRequestException(ERROR_INVALID_SLUG);
+    }
+
+    const userId = req.user?.userId as number;
+    const article = await this.articleService.favoriteArticle(userId, slug);
+    return {
+      message: 'Article favorited successfully',
+      data: article,
+    };
+  }
+
+  @Delete('articles/:slug/unfavorite')
+  @HttpCode(HttpStatus.OK)
+  @Auth(AuthType.ACCESS_TOKEN)
+  async unfavorite(
+    @Req() req: Request,
+    @Param('slug') slug: string,
+  ): Promise<ResponsePayload> {
+    if (!slug || slug.trim() === '') {
+      throw new BadRequestException(ERROR_INVALID_SLUG);
+    }
+
+    const userId = req.user?.userId as number;
+    const article = await this.articleService.unfavoriteArticle(userId, slug);
+    return {
+      message: 'Article unfavorited successfully',
+      data: article,
+    };
+  }
 }


### PR DESCRIPTION
This pull request introduces functionality for favoriting and unfavoriting articles, enabling users to interact with articles and curate personalized content preferences.
1. Favorite Article (POST `/api/articles/:slug/favorite`)
- Requires authentication
- Allows the authenticated user to favorite a specific article identified by its slug
- Checks if the article exists and if the user has already favorited it
- Prevents duplicate favoriting by returning a 409 Conflict if already favorited
- On success, returns the updated article with `favorited`: `true`
- Updated `favoritesCount`
- Author information with current user's follow status

2. Unfavorite Article (DELETE `/api/articles/:slug/favorite`)
- Requires authentication
- Lets the user unfavorite a previously favorited article
- Ensures the article exists and was previously favorited by the user
- Returns a 409 Conflict if the article hasn't been favorited
- On success, returns the updated article with `favorited`: `false`
- Updated `favoritesCount`
- Author details consistent with profile format