### PR TITLE
Pull Request: Add commentsCount to Article Response

### DIFF
--- a/src/common/type/article-response.interface.ts
+++ b/src/common/type/article-response.interface.ts
@@ -13,6 +13,10 @@ interface ArticleFavoritedBy {
   id: number;
 }
 
+interface ArticleComment {
+  id: number;
+}
+
 export interface Article {
   slug: string;
   title: string;
@@ -23,6 +27,7 @@ export interface Article {
   updatedAt: Date;
   favoritedBy: ArticleFavoritedBy[];
   author: ArticleAuthor;
+  comments: ArticleComment[];
 }
 
 export interface ArticleResponseData {
@@ -35,6 +40,7 @@ export interface ArticleResponseData {
   updatedAt: Date;
   favorited?: boolean;
   favoritesCount: number;
+  commentsCount: number;
   author: {
     username: string;
     bio: string | null;

--- a/src/modules/article/article.service.ts
+++ b/src/modules/article/article.service.ts
@@ -44,7 +44,7 @@ export class ArticleService {
         title: true,
         description: true,
         body: true,
-        tagList: true,
+        tagList: { select: { name: true } },
         createdAt: true,
         updatedAt: true,
         favoritedBy: { select: { id: true } },
@@ -57,6 +57,7 @@ export class ArticleService {
             followers: { select: { id: true } },
           },
         },
+        comments: { select: { id: true } },
       },
     });
 
@@ -111,6 +112,7 @@ export class ArticleService {
         },
         tagList: { select: { name: true } },
         favoritedBy: { select: { id: true } },
+        comments: { select: { id: true } },
       },
     });
 
@@ -193,6 +195,7 @@ export class ArticleService {
             followers: { select: { id: true } },
           },
         },
+        comments: { select: { id: true } },
       },
     });
 
@@ -227,6 +230,7 @@ export class ArticleService {
         },
         tagList: { select: { name: true } },
         favoritedBy: { select: { id: true } },
+        comments: { select: { id: true } },
       },
     });
 
@@ -240,7 +244,10 @@ export class ArticleService {
     };
   }
 
-  async feedArticles(currentUserId: number, query: ListArticlesQueryDto) {
+  async feedArticles(
+    currentUserId: number,
+    query: ListArticlesQueryDto,
+  ): Promise<MutlipleArticleResponse> {
     const limit = query.limit ?? ARTICLE_PAGINATION_DEFAULT_LIMIT;
     const offset = query.offset ?? ARTICLE_PAGINATION_DEFAULT_OFFSET;
 
@@ -270,6 +277,7 @@ export class ArticleService {
         },
         tagList: { select: { name: true } },
         favoritedBy: { select: { id: true } },
+        comments: { select: { id: true } },
       },
     });
 
@@ -318,8 +326,8 @@ export class ArticleService {
       where: { id: article.id },
       data: { favoritedBy: { connect: { id: userId } } },
       include: {
-        favoritedBy: true,
-        tagList: true,
+        favoritedBy: { select: { id: true } },
+        tagList: { select: { name: true } },
         author: {
           select: {
             username: true,
@@ -328,6 +336,7 @@ export class ArticleService {
             followers: { select: { id: true } },
           },
         },
+        comments: { select: { id: true } },
       },
     });
 
@@ -370,8 +379,8 @@ export class ArticleService {
       where: { id: article.id },
       data: { favoritedBy: { disconnect: { id: userId } } },
       include: {
-        favoritedBy: true,
-        tagList: true,
+        favoritedBy: { select: { id: true } },
+        tagList: { select: { name: true } },
         author: {
           select: {
             username: true,
@@ -380,6 +389,7 @@ export class ArticleService {
             followers: { select: { id: true } },
           },
         },
+        comments: { select: { id: true } },
       },
     });
 
@@ -402,6 +412,7 @@ export class ArticleService {
         ? article.favoritedBy.some((user) => user.id === userId)
         : undefined,
       favoritesCount: article.favoritedBy.length,
+      commentsCount: article.comments.length,
       author: {
         username: article.author.username,
         bio: article.author.bio,


### PR DESCRIPTION
This pull request introduces a new field commentsCount to the article response object and ensures it's consistently included across all service methods returning article data.
1. Add `commentsCount` to `ArticleResponseData` interface.
2. Include `comments: { select: { id: true } }` in all Prisma queries returning articles.
3. Update the `buildArticleResponse()` method to compute and return `commentsCount`.
4. Applied the enhancement to endpoints:
- `getArticleBySlug` (GET `/api/articles/:slug`)
- `createArticle` (POST `/api/articles`)
- `updateArticle` (PUT `/api/articles/:slug`)
- `listArticles` (GET `/api/articles`)
- `feedArticles` (GET `/api/articles/feed`)
- `favoriteArticle` (POST `/api/articles/:slug/favorite`)
- `unfavoriteArticle` (DELETE `/api/articles/:slug/unfavorite`)